### PR TITLE
Failed to launch the browser process fix

### DIFF
--- a/lib/client/BrowserClient.js
+++ b/lib/client/BrowserClient.js
@@ -78,6 +78,7 @@ module.exports = class Client extends EventEmitter {
   async newPage() {
     this.browser = await puppeteer.launch({
       headless: this.headless,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"]
     });
     const context = this.browser.defaultBrowserContext();
     context.overridePermissions('https://trovo.live', ['notifications']);


### PR DESCRIPTION
This fixes error when starting TrovoBot on Linux Ubuntu 20.04.1 Server.